### PR TITLE
Move completed books checkmark on left, line up titles

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -141,11 +141,10 @@ div#divbooktable {
 a.book-title:before {
     content: '';
     display: inline-block;
-    offset-anchor: right;
     width: 16px;
     height: 16px;
     vertical-align: baseline;
-    margin-right: 0.5rem;
+    margin-right: 8px;
 }
 
 /* show a check mark for completed books */

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -137,9 +137,27 @@ div#divbooktable {
     margin-left: auto;
 }
 
-a.completed_book:after {
+/* blank space to hang completed_book bullets while maintaining proper justification on the whole column */
+a.book-title:before {
+    content: '';
+    display: inline-block;
+    offset-anchor: right;
+    width: 16px;
+    height: 16px;
+    vertical-align: baseline;
+    margin-right: 0.5rem;
+}
+
+/* show a check mark for completed books */
+a.completed_book:before {
     content: url('/static/icn/tick.png');
-    margin-left: 5px;
+}
+
+/**
+  *  when the books list contains NO completed books, get rid of the awkward indent
+  */
+table#booktable:not(:has(a.completed_book)) a.book-title:before {
+    display: none;
 }
 
 /* End book listing */

--- a/lute/templates/book/tablelisting.html
+++ b/lute/templates/book/tablelisting.html
@@ -47,15 +47,15 @@
             let pgfraction = '';
 
             const completed = (parseInt(row[11]) == 1);
-            let completed_style = '';
+            let book_title_classes = ['book-title'];
             if (completed) {
-              completed_style = 'class="completed_book"';
+              book_title_classes.push('completed_book');
             }
             else if (pgnum > 1) {
               pgfraction = ` (${pgnum}/${pgcount})`;
             }
 
-            return `<a ${completed_style} href="/read/${bkid}">${row[0]}${pgfraction}</a>`;
+            return `<a class="${book_title_classes.join(' ')}" href="/read/${bkid}">${row[0]}${pgfraction}</a>`;
           }
         },
         { "name": "LgName", "targets": 1 },


### PR DESCRIPTION
this fixes #57 by doing the following:

1. adds a class `book-title` to all book title links, so they can all be targeted easily with css
2. adds an empty placeholder in front of all `a.book-title` links so the indention is consistent
3. shows `tick.png` in the placeholder space on all `a.book-title.completed_book` links
4. adds a selector with good-but-not-perfect browser support* that removes indentation when the list contains zero completed books. On unsupported browsers the indent will remain even if there are no completed books.

* the `:has()` selector works in every modern browser, but firefox only added support in the most recent version (Dec, '23) 