### PR TITLE
Exit demo mode option added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea/
+
 # mkdocs documentation
 /site
 

--- a/lute/app_factory.py
+++ b/lute/app_factory.py
@@ -150,6 +150,18 @@ def _add_base_routes(app, app_config):
             change your <a href="/settings/index">Settings</a> as needed.)</i>
             """
             flash(msg)
+        return redirect("/", 302)\
+
+    @app.route("/remove_demo_flag")
+    def remove_demo():
+        if lute.db.demo.contains_demo_data():
+            lute.db.demo.remove_flag()
+            msg = """
+            Demo mode deactivated. Have fun! <br /><br />
+            <i>(Lute has automatically enabled backups --
+            change your <a href="/settings/index">Settings</a> as needed.)</i>
+                        """
+            flash(msg)
         return redirect("/", 302)
 
     @app.route("/version")

--- a/lute/db/demo.py
+++ b/lute/db/demo.py
@@ -36,6 +36,9 @@ def remove_flag():
     """
     Remove IsDemoData setting.
     """
+    if not contains_demo_data():
+        raise RuntimeError("Can't delete non-demo data.")
+
     SystemSetting.delete_key("IsDemoData")
     db.session.commit()
 

--- a/lute/templates/index.html
+++ b/lute/templates/index.html
@@ -16,6 +16,9 @@
   <p>When you're done trying out the demo, <a href="/wipe_database"
   style="text-decoration: underline;">click here</a> to clear out the
   database.  <i>Note: this removes everything in the db.</i></p>
+  <p>Or instead,
+    <a href="/remove_demo_flag" style="text-decoration: underline;">dimiss</a>
+    this message.
   </p>
 </div>
 {% endif %}


### PR DESCRIPTION
A feature that @tg_kroening174 on Discord and I miss:

Dismissing the "_When you're done trying out the demo, [...]_" message without wiping the database clean.

I also added a `.gitignore` line for PyCharm project settings.