### PR TITLE
Fix issue #13: Ability to delete a term from reading screen

### DIFF
--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -81,6 +81,13 @@
         <a href="" onclick="show_term_sentences(); return false;">Sentences</a>
         <button id="submit" type="submit" class="btn btn-primary">Save</button>
       </td>
+      {% if term.id %}
+    <tr>
+      <td align="right">
+        <button id="delete" type="button" class="btn" onclick="deleteTerm()">Delete</button>
+      </td>
+    </tr>
+      {% endif %}
     </tr>
 
   </tbody>
@@ -397,5 +404,26 @@
     const url = `/term/sentences/${langid}/${t}`;
     top.frames.dictframe.location.href = url;
   }
+
+  function deleteTerm() {
+        // Ask for confirmation
+        var isConfirmed = confirm('Are you sure you want to delete this term?\n\nThis action cannot be undone, and if this term has children, they will be orphaned.');
+
+        // Check if the user confirmed
+        if (isConfirmed) {
+            // Delete term
+            fetch("/term/delete/{{ term.id }}")
+
+            if ("{{ embedded_in_reading_frame }}" == "True") {
+              // If on reading page, reload page
+              parent.location.reload();
+            }
+            else {
+              // If on term page, go to term listing
+              window.location.href = '/term/index';
+            }
+        }
+   }
+
 
 </script>

--- a/lute/templates/term/formframes.html
+++ b/lute/templates/term/formframes.html
@@ -7,16 +7,7 @@
 {% block body %}
 <div id="term_form_left">
   {% include('term/_form.html') %}
-  <a href="/term/index">back to list</a>
-
-  {% if term.id %}
-  <form
-    method="post"
-    action="/term/delete/{{ term.id }}"
-    onsubmit="return confirm('Are you sure you want to delete this item?');">
-    <button class="btn">Delete</button>
-  </form>
-  {% endif %}
+  <a href="/term/index">Back to all terms</a>
 </div>
 
 

--- a/lute/term/routes.py
+++ b/lute/term/routes.py
@@ -200,7 +200,7 @@ def bulk_set_parent():
     return jsonify("ok")
 
 
-@bp.route("/delete/<int:termid>", methods=["POST"])
+@bp.route("/delete/<int:termid>", methods=["GET"])
 def delete(termid):
     """
     Delete a term.


### PR DESCRIPTION
Added delete term button in term form, visible in both `/read` and `/term/edit`:
 Button in `/read` reloads the page
 Button in `/term/edit` redirects to `/term/index`

Removed old delete button in `/term/edit`

Check if you're fine with the layout, I've placed the button below the "save" button, in the next table row.
This is the first JS code I have ever written lol, but it works.