### PR TITLE
Scroll to top after term save - fix

### DIFF
--- a/lute/static/js/text-options.js
+++ b/lute/static/js/text-options.js
@@ -17,7 +17,7 @@ const widthMinusButton = document.querySelector(".width-minus");
 const oneColButton = document.querySelector(".column-one");
 const twoColButton = document.querySelector(".column-two");
 
-const theText = document.querySelector("#thetext");
+// const theText = document.querySelector("#thetext");
 
 const domObserver = new MutationObserver((mutationList, observer) => {
   textItems = document.querySelectorAll("span.textitem");

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -203,14 +203,11 @@
 
   window.addEventListener("scrollend", function(e) {
     scrollYBeforeReload = window.scrollY;
-    console.log(scrollYBeforeReload);
   });
 
   $(document).ready(function () {
     const theTextReloadObs = new MutationObserver((mutationList, observer) => {
-      console.log(scrollYBeforeReload);
       if (scrollYBeforeReload) window.scrollTo(0, scrollYBeforeReload);
-      console.log("ADASD");
     });
     
     theTextReloadObs.observe(theText, {childList: true, subtree: true});

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -180,14 +180,11 @@
 <script>
   let mouseY;
   let scrollY;
+  let scrollYBeforeReload;
   const mediaTablet = window.matchMedia("(max-width: 980px)");
   const readPaneRight = document.getElementById("read_pane_right");
   const btmMarginCont = document.querySelector(".btm-margin-container");
-
-  document.addEventListener("click", (event) => {
-    mouseY = event.clientY;
-    scrollY = window.scrollY;
-  });
+  const theText = document.getElementById("thetext");
 
   // fixes the "bug" where if right pane is opened in mobile view and after the screen is resized up,
   // right pane doesn't translate up to 0 because of inline transform property
@@ -199,7 +196,25 @@
     }
   })
 
+  document.addEventListener("click", (event) => {
+      mouseY = event.clientY;
+      scrollY = window.scrollY;
+  });
+
+  window.addEventListener("scrollend", function(e) {
+    scrollYBeforeReload = window.scrollY;
+    console.log(scrollYBeforeReload);
+  });
+
   $(document).ready(function () {
+    const theTextReloadObs = new MutationObserver((mutationList, observer) => {
+      console.log(scrollYBeforeReload);
+      if (scrollYBeforeReload) window.scrollTo(0, scrollYBeforeReload);
+      console.log("ADASD");
+    });
+    
+    theTextReloadObs.observe(theText, {childList: true, subtree: true});
+    
     if (have_audio_file()) {
       // Don't actually load the source -- for some reason,
       // the ajax page load was causing the audio src to


### PR DESCRIPTION
This PR fixes #111 by saving the scroll position and setting it back after `thetext` reload

Tested in Chrome and Firefox