### PR TITLE
Fix spelling of "dismiss" in anchor tag for remove_demo_flag

### DIFF
--- a/lute/templates/index.html
+++ b/lute/templates/index.html
@@ -17,7 +17,7 @@
   style="text-decoration: underline;">click here</a> to clear out the
   database.  <i>Note: this removes everything in the db.</i></p>
   <p>Or instead,
-    <a href="/remove_demo_flag" style="text-decoration: underline;">dimiss</a>
+    <a href="/remove_demo_flag" style="text-decoration: underline;">dismiss</a>
     this message.
   </p>
 </div>


### PR DESCRIPTION
Fix spelling of "dismiss" in an anchor tag.