### PR TITLE
Fix toggle highlights classes are not removed when mouseout

### DIFF
--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -65,6 +65,7 @@ function prepareTextInteractions(pos) {
 
   if (!_show_highlights()) {
     t.on('mouseover', '.word', hover_over_add_status_class);
+    t.on('mouseout', '.word', remove_status_highlights);
   }
 
   $(document).on('keydown', handle_keydown);


### PR DESCRIPTION
In toggle highlight mode, cursor does not hover over the word but it still highlights it:

![image](https://github.com/jzohrab/lute-v3/assets/36101415/4f444dbe-ab3f-4538-af62-d35d81d11cc8)

Fixed:

![image](https://github.com/jzohrab/lute-v3/assets/36101415/94011562-7a76-4c72-97bd-62366bcec020)