### PR TITLE
Issue 289 clarify js globals

### DIFF
--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -6,6 +6,12 @@
  */
 class LookupButton {
 
+  /** State required by the buttons. */
+  static TERM_FORM_CONTAINER = null;
+  static TERM_DICTS = null;
+  static LANG_ID = null;
+
+
   /** All LookupButtons created. */
   static all = [];
 
@@ -84,13 +90,14 @@ class GeneralLookupButton extends LookupButton {
 class SentenceLookupButton extends GeneralLookupButton {
   constructor() {
     let handler = function(iframe) {
-      const txt = TERM_FORM_CONTAINER.querySelector("#text").value;
+      const txt = LookupButton.TERM_FORM_CONTAINER.querySelector("#text").value;
       // %E2%80%8B is the zero-width string.  The term is reparsed
       // on the server, so this doesn't need to be sent.
       const t = encodeURIComponent(txt).replaceAll('%E2%80%8B', '');
-      if (LANG_ID == '0' || t == '')
+      const langid = `${LookupButton.LANG_ID ?? 0}`;
+      if (langid == '0' || t == '')
         return;
-      iframe.setAttribute("src", `/term/sentences/${LANG_ID}/${t}`);
+      iframe.setAttribute("src", `/term/sentences/${LookupButton.LANG_ID}/${t}`);
     };
 
     super("sentences-btn", "Sentences", "See term usage", "dict-sentences-btn", handler);
@@ -103,15 +110,16 @@ class ImageLookupButton extends GeneralLookupButton {
 
     // Parents are in the tagify-managed #parentslist input box.
     let _get_parent_tag_values = function() {
-      const pdata = TERM_FORM_CONTAINER.querySelector("#parentslist").value
+      const pdata = LookupButton.TERM_FORM_CONTAINER.querySelector("#parentslist").value
       if ((pdata ?? '') == '')
         return [];
       return JSON.parse(pdata).map(e => e.value);
     };
 
     let handler = function(iframe) {
-      const text = TERM_FORM_CONTAINER.querySelector("#text").value;
-      if (LANG_ID == null || LANG_ID == '' || parseInt(LANG_ID) == 0 || text == null || text == '') {
+      const text = LookupButton.TERM_FORM_CONTAINER.querySelector("#text").value;
+      const lang_id = LookupButton.LANG_ID;
+      if (lang_id == null || lang_id == '' || parseInt(lang_id) == 0 || text == null || text == '') {
         alert('Please select a language and enter the term.');
         return;
       }
@@ -124,7 +132,7 @@ class ImageLookupButton extends GeneralLookupButton {
 
       const raw_bing_url = 'https://www.bing.com/images/search?q=###&form=HDRSC2&first=1&tsc=ImageHoverTitle';
       const binghash = raw_bing_url.replace('https://www.bing.com/images/search?', '');
-      const url = `/bing/search/${LANG_ID}/${encodeURIComponent(use_text)}/${encodeURIComponent(binghash)}`;
+      const url = `/bing/search/${LookupButton.LANG_ID}/${encodeURIComponent(use_text)}/${encodeURIComponent(binghash)}`;
 
       iframe.setAttribute("src", url);
     };  // end handler
@@ -146,7 +154,7 @@ class DictButton extends LookupButton {
   constructor(dictURL, frameName) {
     super(frameName);
 
-    this.dictID = TERM_DICTS.indexOf(dictURL);
+    this.dictID = LookupButton.TERM_DICTS.indexOf(dictURL);
     if (this.dictID == -1) {
       console.log(`Error: Dict url ${dictURL} not found (??)`);
       return;
@@ -190,8 +198,10 @@ class DictButton extends LookupButton {
   /** LOOKUPS *************************/
 
   do_lookup() {
-    const dicturl = TERM_DICTS[this.dictID];
-    const term = TERM_FORM_CONTAINER.querySelector("#text").value;
+    const dicturl = LookupButton.TERM_DICTS[this.dictID];
+    if (LookupButton.TERM_FORM_CONTAINER == null || dicturl == null)
+      return;
+    const term = LookupButton.TERM_FORM_CONTAINER.querySelector("#text").value;
     if (this.isExternal) {
       this._load_popup(dicturl, term);
     }
@@ -245,7 +255,7 @@ class DictButton extends LookupButton {
       // TODO handle_image_lookup_separately: don't mix term lookups with image lookups.
       let use_text = text;
       const binghash = dicturl.replace('https://www.bing.com/images/search?', '');
-      url = `/bing/search/${LANG_ID}/${encodeURIComponent(use_text)}/${encodeURIComponent(binghash)}`;
+      url = `/bing/search/${LookupButton.LANG_ID}/${encodeURIComponent(use_text)}/${encodeURIComponent(binghash)}`;
     }
 
     this.frame.setAttribute("src", url);
@@ -303,18 +313,18 @@ function createLookupButtons(tab_count = 5) {
   destroy_existing_dictTab_controls();
   LookupButton.all = [];
 
-  if (TERM_DICTS.length <= 0) return;
+  if (LookupButton.TERM_DICTS.length <= 0) return;
 
   // const dev_hack_add_dicts = Array.from({ length: 5 }, (_, i) => `a${i}`);
-  // TERM_DICTS.push(...dev_hack_add_dicts);
+  // LookupButton.TERM_DICTS.push(...dev_hack_add_dicts);
 
-  if (tab_count == (TERM_DICTS.length - 1)) {
+  if (tab_count == (LookupButton.TERM_DICTS.length - 1)) {
     // Don't bother making a list with a single item.
     tab_count += 1;
   }
 
   // Make all DictButtons, which loads LookupButton.all.
-  TERM_DICTS.forEach((dict, index) => { new DictButton(dict,`dict${index}`); });
+  LookupButton.TERM_DICTS.forEach((dict, index) => { new DictButton(dict,`dict${index}`); });
   const tab_buttons = LookupButton.all.slice(0, tab_count);
   const list_buttons = LookupButton.all.slice(tab_count);
 

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="{{ url_for('static', filename='js/player.js') }}" charset="utf-8" defer></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/resize.js') }}" charset="utf-8" defer></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/text-options.js') }}" charset="utf-8" defer></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/dict-tabs.js') }}" charset="utf-8" defer></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/dict-tabs.js') }}" charset="utf-8"></script>
 
 <div id="rendering_controls" style="display: none">
   <pre>
@@ -180,11 +180,8 @@
 </div>
 
 <script>
-  // used in dict-tabs.js
-  const LANG_ID = {{ lang_id | safe }};
-  const TERM_DICTS = {{ term_dicts | safe }};
-  // because read term field is in iframe, but new term field is not
-  let TERM_FORM_CONTAINER;
+  LookupButton.LANG_ID = {{ lang_id | safe }};
+  LookupButton.TERM_DICTS = {{ term_dicts | safe }};
 
   let mouseY;
   let scrollY;
@@ -245,7 +242,7 @@
 
     window.addEventListener("message", function(event) {
       if (event.data.event === "LuteTermFormOpened") {
-        TERM_FORM_CONTAINER = wordFrame.contentDocument.getElementById("term-form-container");
+        LookupButton.TERM_FORM_CONTAINER = wordFrame.contentDocument.getElementById("term-form-container");
         loadDictionaries();
       }
 

--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -1,3 +1,5 @@
+<script type="text/javascript" src="{{ url_for('static', filename='js/dict-tabs.js') }}" charset="utf-8"></script>
+
 {% for field_name, field_errors in form.errors.items() %}
 {% for error in field_errors %}
 <div class="flash-notice-narrow">{{ error }}</div>
@@ -64,13 +66,7 @@
 <script>
   // this is used in formframes.html
   const ALL_DICTS = {{ language_dicts | safe }};
-  const TERM_FORM_CONTAINER = document.getElementById("term-form-container");
-  let TERM_DICTS;
-  let LANG_ID;
 </script>
-
-<!-- do not defer. if deferred it gets loaded at the end of formframes. bu we need it to load after _form, but before formframes -->
-<script type="text/javascript" src="{{ url_for('static', filename='js/dict-tabs.js') }}" charset="utf-8"></script>
 
 <script type="text/javascript">
 
@@ -342,7 +338,8 @@
     window.parent.postMessage({ event: "LuteTermFormOpened" }, "*");
 
     enable_disable_sync_status_checkbox();
-  });
+  });  // end $(document).ready
+
 
   function deleteTerm() {
     const msg = "Are you sure you want to delete this term?\n\n" +

--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -63,10 +63,6 @@
   </form>
 </div>
 
-<script>
-  // this is used in formframes.html
-  const ALL_DICTS = {{ language_dicts | safe }};
-</script>
 
 <script type="text/javascript">
 

--- a/lute/templates/term/formframes.html
+++ b/lute/templates/term/formframes.html
@@ -31,27 +31,33 @@
     let old_term = "";
     let old_langid = 0;
 
+    LookupButton.TERM_FORM_CONTAINER = document.getElementById("term-form-container");
+    LookupButton.LANG_ID = 0;
+    LookupButton.TERM_DICTS = [];
+
     loadDictsBtn.addEventListener("click", (e) => {
       e.preventDefault();
 
-      LANG_ID = langSelect.value;
-      if (LANG_ID == 0 || !termField.value)
+      let selected_lang_id = langSelect.value;
+      if (selected_lang_id == 0 || !termField.value)
         return;
 
-      const lang_changed = LANG_ID != old_langid;
+      const lang_changed = selected_lang_id != old_langid;
       const term_changed = termField.value != old_term;
       if (lang_changed) {
         // New language = new buttons, rebuild it all.
-        TERM_DICTS = ALL_DICTS[LANG_ID].term;
+        LookupButton.LANG_ID = selected_lang_id;
+        LookupButton.TERM_DICTS = ALL_DICTS[selected_lang_id].term;
         createLookupButtons();
       }
       if (lang_changed || term_changed) {
         // Refresh the tabs if needed.
+        LookupButton.LANG_ID = selected_lang_id;
         loadDictionaries();
       }
 
       old_term = termField.value;
-      old_langid = LANG_ID;
+      old_langid = selected_lang_id;
       
     })
   </script>
@@ -59,8 +65,9 @@
 {% else %}
 
   <script>
-    LANG_ID = $('#language_id').val();
-    TERM_DICTS = ALL_DICTS[LANG_ID].term;
+    LookupButton.TERM_FORM_CONTAINER = document.getElementById("term-form-container");
+    LookupButton.LANG_ID = $('#language_id').val();
+    LookupButton.TERM_DICTS = ALL_DICTS[LookupButton.LANG_ID].term;
     createLookupButtons();
     loadDictionaries();
   </script>

--- a/lute/templates/term/formframes.html
+++ b/lute/templates/term/formframes.html
@@ -31,6 +31,7 @@
     let old_term = "";
     let old_langid = 0;
 
+    const ALL_DICTS = {{ language_dicts | safe }};
     LookupButton.TERM_FORM_CONTAINER = document.getElementById("term-form-container");
     LookupButton.LANG_ID = 0;
     LookupButton.TERM_DICTS = [];
@@ -65,6 +66,7 @@
 {% else %}
 
   <script>
+    const ALL_DICTS = {{ language_dicts | safe }};
     LookupButton.TERM_FORM_CONTAINER = document.getElementById("term-form-container");
     LookupButton.LANG_ID = $('#language_id').val();
     LookupButton.TERM_DICTS = ALL_DICTS[LookupButton.LANG_ID].term;


### PR DESCRIPTION
Addresses #289.

Add `LookupButton` static vars:

```
  static TERM_FORM_CONTAINER = null;
  static TERM_DICTS = null;
  static LANG_ID = null;
```

The existing code creates global vars in a few places (either with let or const), and the LookupButton class uses these globals.  Declaring them static clarifies the intent of the variables, removes any ambiguity, and moves declaration into one place.

Many changed lines just add the LookupButton name to the var, eg `TERM_DICTS` becomes `LookupButton.TERM_DICTS`.