### PR TITLE
Fix Issue 16: clicking a word redirects to dictionary

### DIFF
--- a/lute/db/demo/languages/classical_chinese.yaml
+++ b/lute/db/demo/languages/classical_chinese.yaml
@@ -2,7 +2,7 @@ name: Classical Chinese
 dictionaries:
   - for: terms
     type: embedded
-    url: https://ctext.org/dictionary.pl?if=en&char=###
+    url: https://www.archchinese.com/chinese_english_dictionary.html?find=###
   - for: sentences
     type: popup
     url: https://www.deepl.com/translator#ch/en/###

--- a/lute/db/schema/baseline.sql
+++ b/lute/db/schema/baseline.sql
@@ -228,7 +228,7 @@ CREATE TABLE languagedicts (
 INSERT INTO languagedicts VALUES(1,1,'terms','embeddedhtml','https://www.arabicstudentsdictionary.com/search?q=###',1,1);
 INSERT INTO languagedicts VALUES(2,1,'terms','popuphtml','https://translate.google.com/?hl=es&sl=ar&tl=en&text=###&op=translate',1,2);
 INSERT INTO languagedicts VALUES(3,1,'sentences','popuphtml','https://translate.google.com/?hl=es&sl=ar&tl=en&text=###',1,3);
-INSERT INTO languagedicts VALUES(4,2,'terms','embeddedhtml','https://ctext.org/dictionary.pl?if=en&char=###',1,1);
+INSERT INTO languagedicts VALUES(4,2,'terms','embeddedhtml','https://www.archchinese.com/chinese_english_dictionary.html?find=###',1,1);
 INSERT INTO languagedicts VALUES(5,2,'sentences','popuphtml','https://www.deepl.com/translator#ch/en/###',1,2);
 INSERT INTO languagedicts VALUES(6,3,'terms','embeddedhtml','https://slovniky.lingea.cz/Anglicko-cesky/###',1,1);
 INSERT INTO languagedicts VALUES(7,3,'terms','embeddedhtml','https://slovnik.seznam.cz/preklad/cesky_anglicky/###',1,2);


### PR DESCRIPTION
**Problem**: #16

The following script runs on the ctext.org so when the dictionary is embedded it redirects to the ctext.org

```js
if (top.location != self.location) { top.location = self.location; }
```

**Solutions**
- changing ctext.org to popup
- using another dictionary

**Alternative Dictionaries**
https://en.wiktionary.org/wiki/###
https://www.archchinese.com/chinese_english_dictionary.html?find=###
https://www.mdbg.net/chinese/dictionary?page=worddict&wdrst=1&wdqb=###
*https://www.xiaoma.info/hanzi.php?hz=###

**Fix**
I changed the dictionary to archchinese.