### PR TITLE
Add ability to open a new Lute tab

### DIFF
--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -46,12 +46,14 @@
             <span class="hamburger"></span>
             <span class="hamburger"></span>
           </div>
-          <img
-          src="{{ url_for('static', filename='img/lute.png') }}"
-          class="lutelogo_small"
-          style="cursor: pointer"
-          title="Home"
-          onclick="window.location='/'" />
+	  <a href="/">
+		<img
+		  src="{{ url_for('static', filename='img/lute.png') }}"
+		  class="lutelogo_small"
+		  style="cursor: pointer"
+		  title="Home"
+		/>
+	  </a>
         </div>
         <div class="reading_header_mid">
         <div class="reading_header_mid_top">

--- a/lute/templates/read/reading_menu.html
+++ b/lute/templates/read/reading_menu.html
@@ -1,9 +1,11 @@
 <div class="reading_menu_logo_container">
-  <img
-    src="{{ url_for('static', filename='img/lute.png') }}"
-    class="lutelogo_small"
-    style="cursor: pointer"
-    onclick="window.location='/'" />
+  <a href="/">
+    <img
+      src="{{ url_for('static', filename='img/lute.png') }}"
+      class="lutelogo_small"
+      style="cursor: pointer"
+    />
+  </a>
   <!-- <h2>Lute</h2> -->
   <button class="close-btn reading-menu-close-btn" onclick="closeMenu()"></button>
 </div>


### PR DESCRIPTION
Fixes #312 
- [x] Enclose lute images within anchor tag.
- [x] This makes the image right clickable.