### PR TITLE
Fix title and tooltip overflow

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -582,6 +582,7 @@ div#reading-footer span {
 #thetexttitle {
     font-size: 1.5rem;
     margin-bottom: 1rem;
+    word-wrap: break-word;
 }
 
 #thetexttitle,
@@ -791,6 +792,7 @@ img
 div.ui-tooltip {
     max-width: 400px !important;
     z-index: 1000; /*higher than audio because of words on the bottom, but lower than header and side menu */
+    word-wrap: break-word;
 }
 
 .tooltip-image {


### PR DESCRIPTION
Before:

![image](https://github.com/jzohrab/lute-v3/assets/36101415/9948d8d0-bd78-4e5d-9e0b-8af4a0f45932)

After:

![image](https://github.com/jzohrab/lute-v3/assets/36101415/11d19cf3-fcba-4625-aa33-655a0b6d7d1e)