### PR TITLE
Issue 339 retain zero-width joiner and non-joiner characters

### DIFF
--- a/lute/db/demo/languages/hindi.yaml
+++ b/lute/db/demo/languages/hindi.yaml
@@ -3,6 +3,9 @@ dictionaries:
   - for: terms
     type: embedded
     url: https://www.boltidictionary.com/en/search?s=###
+  - for: terms
+    type: popup
+    url: https://translate.google.com/?sl=hi&tl=en&text=###
   - for: sentences
     type: embedded
     url: https://www.bing.com/translator/?from=hi&to=en&text=###
@@ -13,4 +16,4 @@ show_romanization: true
 # character_substitutions:
 split_sentences: .?!|।॥
 split_sentence_exceptions: Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.
-word_chars: a-zA-Z\u0900-\u0963\u0966-\u097F
+word_chars: a-zA-Z\u0900-\u0963\u0966-\u097F\u200C\u200D

--- a/lute/db/schema/baseline.sql
+++ b/lute/db/schema/baseline.sql
@@ -277,9 +277,9 @@ INSERT INTO languages VALUES(2,'Classical Chinese','´=''|`=''|’=''|‘=''|...
 INSERT INTO languages VALUES(3,'Czech','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-ZÀ-ÖØ-öø-ȳáéíóúÁÉÍÓÚñÑ',0,1,'spacedel');
 INSERT INTO languages VALUES(4,'English','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-ZÀ-ÖØ-öø-ȳáéíóúÁÉÍÓÚñÑ',0,0,'spacedel');
 INSERT INTO languages VALUES(5,'French','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-ZÀ-ÖØ-öø-ȳáéíóúÁÉÍÓÚñÑ',0,0,'spacedel');
-INSERT INTO languages VALUES(6,'German','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-ZÀ-ÖØ-öø-ȳáéíóúÁÉÍÓÚñÑ',0,0,'spacedel');
+INSERT INTO languages VALUES(6,'German','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-ZÀ-ÖØ-öø-ȳáéíóúÁÉÍÓÚñÑ\u200C\u200D',0,0,'spacedel');
 INSERT INTO languages VALUES(7,'Greek','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?;','Mr.|Mrs.|Dr.|[A-Z].|κτλ.|κλπ.|π.χ.|λ.χ.|κ.ά|δηλ.|Κος.|Κ.|Κα.|μ.Χ.|ΥΓ.|μ.μ.|π.μ.|σελ.|κεφ.|βλ.|αι.','α-ωΑ-ΩάόήέώύίΊΏΈΉΌΆΎϊΪϋΫΐΰ',0,1,'spacedel');
-INSERT INTO languages VALUES(8,'Hindi','´=''|`=''|’=''|‘=''|...=…|..=‥','.?!|।॥','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-Z\u0900-\u0963\u0966-\u097F',0,1,'spacedel');
+INSERT INTO languages VALUES(8,'Hindi','´=''|`=''|’=''|‘=''|...=…|..=‥','.?!|।॥','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-Z\u0900-\u0963\u0966-\u097F\u200C\u200D',0,1,'spacedel');
 INSERT INTO languages VALUES(9,'Japanese','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?。？！','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','\p{Han}\p{Katakana}\p{Hiragana}',0,1,'japanese');
 INSERT INTO languages VALUES(10,'Russian','´=''|`=''|’=''|‘=''|...=…|..=‥','.!?','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','А-Яа-яЁё',0,0,'spacedel');
 INSERT INTO languages VALUES(11,'Sanskrit','´=''|`=''|’=''|‘=''|...=…|..=‥','.?!।॥','Mr.|Mrs.|Dr.|[A-Z].|Vd.|Vds.','a-zA-Z\u0900-\u0963\u0966-\u097F',0,1,'spacedel');

--- a/lute/parse/space_delimited_parser.py
+++ b/lute/parse/space_delimited_parser.py
@@ -31,9 +31,8 @@ class SpaceDelimitedParser(AbstractParser):
         # Remove extra spaces.
         clean_text = re.sub(r" +", " ", text)
 
-        # Remove zero-width spaces, joiners, and non-joiners.
-        for c in (chr(0x200B), chr(0x200C), chr(0x200D)):
-            clean_text = clean_text.replace(c, "")
+        # Remove zero-width spaces.
+        clean_text = clean_text.replace(chr(0x200B), "")
 
         return self._parse_to_tokens(clean_text, language)
 

--- a/tests/unit/parse/test_SpaceDelimitedParser.py
+++ b/tests/unit/parse/test_SpaceDelimitedParser.py
@@ -147,20 +147,24 @@ def test_quick_checks(english):
     assert_string_equals("1234.Hello", english, "1234.[Hello]")
 
 
-def test_zero_width_non_joiner_removed(german):
+def test_zero_width_non_joiner_retained(german):
     """
-    Verify zero-width non-joiner characters are removed before parsing.
+    Verify zero-width joiner characters are retained in languages that
+    include them as word characters.
+
     Test case from https://en.wikipedia.org/wiki/Zero-width_non-joiner.
     """
     assert_string_equals("Brotzeit", german, "[Brotzeit]")
-    assert_string_equals("Brot\u200czeit", german, "[Brotzeit]")
+    assert_string_equals("Brot\u200czeit", german, "[Brot\u200czeit]")
 
 
-def test_zero_width_joiner_removed(hindi):
+def test_zero_width_joiner_retained(hindi):
     """
-    Verify zero-width joiner characters are removed before parsing.
+    Verify zero-width joiner characters are retained in languages that
+    include them as word characters.
+
     We see them used to replace Hindi conjunct characters with individual consonants.
     """
     assert_string_equals("namaste", hindi, "[namaste]")
     assert_string_equals("नमस्ते", hindi, "[नमस्ते]")
-    assert_string_equals("नमस\u200dते", hindi, "[नमसते]")
+    assert_string_equals("नमस\u200dते", hindi, "[नमस\u200dते]")


### PR DESCRIPTION
Fixes #339 and mostly undoes #333 by restoring original space-delimited parser behavior and explicitly adding zero-width joiner and non-joiner characters to the language definitions for German and Hindi to make unit tests pass and demonstrate how to add zero-width joiner and non-joiner support to other languages.

This is the most conservative fix that retains the existing behavior in all other languages and only modifies the word-detection behavior of German and Hindi.