### PR TITLE
Issue 361: tighten up mobile css

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -1772,8 +1772,8 @@ input[type="checkbox"][disabled] + label {
 
     #thetexttitle,
     div#thetext {
-        padding: 0 3.2rem;
-        padding: 0 3.2rem;
+        padding: 0 1rem;
+        padding: 0 1rem;
     }
 
     .reading-menu-item {
@@ -1835,9 +1835,10 @@ input[type="checkbox"][disabled] + label {
         top: 0;
         width: 100%;
         background: var(--background-color);
-        height: 7.5rem;
+        height: 3rem;
         z-index: 1001;
-        box-shadow: 0 0 12px 0 #0000002e;
+        /* box-shadow: 0 0 12px 0 #0000002e; */
+        margin-bottom: 0.5rem;
     }
 
     div.ui-tooltip {
@@ -1846,13 +1847,15 @@ input[type="checkbox"][disabled] + label {
 
     #read_pane_left {
         width: unset !important;
-        margin-top: 10rem;
+        margin-top: 4rem;
     }
 
     .reading_header_container {
         padding-right: 3.2em;
         padding-left: 3.2em;
         align-items: end;
+        gap: 0.5rem;
+        padding: 0.5rem 0.5rem 0 0.5rem;
     }
 
     .reading_header_left {
@@ -1929,26 +1932,27 @@ input[type="checkbox"][disabled] + label {
     }
 
     #read-slider {
-        height: 1.7rem;
+        height: 0.5rem;
     }
 
     #read-slider::-moz-range-thumb {
         width: 2.2rem;
-        height: 2rem;
+        height: 0.5rem;
     }
 
     #read-slider::-webkit-slider-thumb {
         width: 2.2rem;
-        height: 2rem;
+        height: 0.5rem;
     }
 
     .reading_header_mid_top {
         margin-left: 2.3rem;
         margin-right: 2.3rem;
+        margin-bottom: 0.2rem;
     }
 
     .read_page_nav {
-        font-size: 2.2rem;
+        font-size: 1rem;
     }
 
     #page_indicator,
@@ -1962,7 +1966,7 @@ input[type="checkbox"][disabled] + label {
     }
 
     .lutelogo_small {
-        width: 70px;
+        width: 50px;
     }
 
     #booktable td:nth-child(2),

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -1835,9 +1835,8 @@ input[type="checkbox"][disabled] + label {
         top: 0;
         width: 100%;
         background: var(--background-color);
-        height: 3rem;
+        height: 4rem; /* Matches the read_pane_left margin-top. */
         z-index: 1001;
-        /* box-shadow: 0 0 12px 0 #0000002e; */
         margin-bottom: 0.5rem;
     }
 


### PR DESCRIPTION
From issue #361 - the mobile css has a fair amount of whitespace which takes up real estate on smaller devices.  This PR proposes default changes to the css.  Here's a screenshot from my chrome devtools:

Before this change:

> <img width="384" alt="image" src="https://github.com/jzohrab/lute-v3/assets/1637133/3b5f0f35-14ca-481e-9863-f938021af63d">

After:

> <img width="401" alt="image" src="https://github.com/jzohrab/lute-v3/assets/1637133/65980f16-6761-40b4-b02d-a67a5d5822b9">

I think some people are already using mobile so opening this up for review (by @webofpies ) and others.